### PR TITLE
FIX - 상품상세페이지의 리뷰에서 css 문제

### DIFF
--- a/assets/stylesheets/custom/lib/_sprites.scss
+++ b/assets/stylesheets/custom/lib/_sprites.scss
@@ -2,7 +2,7 @@
 
 @mixin sprites {
   vertical-align: middle;
-  background-image: image-url('okkane-co-kr/custom/sprites.png');
+  background-image: image-url('custom/sprites.png');
   background-repeat: no-repeat;
 }
 

--- a/assets/stylesheets/pc/app/products/reviews.css.scss
+++ b/assets/stylesheets/pc/app/products/reviews.css.scss
@@ -382,8 +382,8 @@ body.products.reviews, #review-edit-form {
       position: absolute;
       top: 0;
       left: 0;
-      width: $preview_image_size;
-      height: $preview_image_size;
+      width: 56px;
+      height: 58px;
       font-size: 0;
       background: white;
       text-align: center;

--- a/assets/stylesheets/pc/okkane-co-kr.css.scss
+++ b/assets/stylesheets/pc/okkane-co-kr.css.scss
@@ -92,7 +92,6 @@ body.products.reviews ul.header,
     display: block;
     position: absolute;
     top: 5px;
-    left: 10px;
     @include sprites-okkane-icon-text;
   }
 }


### PR DESCRIPTION
## 원인 및 수정 사항
- [PR](#2)에서 auto generate를 하면서 예상하지 못한 css 충돌이 발생

- 카메라 아이콘이 회색 네모로 나오는 현상
  * custom/lib/_sprites.scss 에서 image-url로 생성되는 url이 `latte/assets/okkane-co-kr/okkane-co-kr/custom/sprites.png`로 okkane-co-kr이 2번 들어간다.
  * 이것 때문에 404 에러가 발생하는데, `latte/assets/okkane-co-kr/custom/sprites.png`로 수정하면 정상 동작함
  * gem 자체 버그인지 정확한 원인 분석이 어려움

- 삭제 문구의 위치 문제
  * sprite-factory에 의해 자동으로 생성된 css가 기존의 css 속성을 overwrite하게 됨
  * $preview_image_size 를 width, height 각각 56, 58px로 바꾼 이유는 `sprites-okkane-btn-add-photo` 에서 56, 58px로 자동적으로 정의되었고, 이것의 크기를 맞춰주기 위함

- 위젯 내에서 카메라 아이콘이 표시되지 않는 문제
  * 카메라 아이콘이 회색 네모로 나오는 현상과 동일한 원인.(url 문제)
  * `sprites-okkane-icon-text`의 속성에 의해 아이콘이 약간 밀려 보여서 left 속성을 제거
  * 첫번째 스크린샷 참조

<img width="547" alt="2017-03-30 6 32 36" src="https://cloud.githubusercontent.com/assets/6479241/24497978/1d8630ec-1578-11e7-946f-4261d4a4a38d.png">



https://app.asana.com/0/222280601547638/305519286566506