### PR TITLE
FIX - 사진 첨부 할때 preview 이미지 잘림

### DIFF
--- a/assets/stylesheets/pc/okkane-co-kr.css.scss
+++ b/assets/stylesheets/pc/okkane-co-kr.css.scss
@@ -42,12 +42,23 @@
   }
 }
 
-body.products.reviews .image-fields-container .image-field .wrap,
-#review-edit-form .image-fields-container .image-field .wrap {
-  @include sprites-okkane-btn-add-photo;
-  background-color: white;
+body.products.reviews, #review-edit-form {
+  .image-fields-container .input-image-container {
+    top: 0;
+    bottom: 0;
+    margin-top: 0;
+    background-color: white;
 
-  .add-image-caption { display: none; }
+    .sprites-icon-camera {
+      @include sprites-okkane-btn-add-photo;
+      display: block;
+      margin: 10px auto;
+    }
+
+    .add-image-caption {
+      display: none;
+    }
+  }
 }
 
 body.products.reviews .image-fields-container .sprites-icon-camera,


### PR DESCRIPTION
### 원인
- https://github.com/crema/crema-okkane.co.kr/commit/3f639408fc1a40a6a94c0f35e7c250ead2df1fce 에서 잘못 수정한 내용
  - 종전의 `@include okkane-co-kr-sprite` 에는 width, height 지정하지 않고 있었음
  - `@include sprites-okkane-btn-add-photo`로 변경되면서 width, height가 지정되기 시작함
  - 종전에 버그가 없었던 이유는 sprite가 우연히 안겹쳤기 때문일뿐, width, height는 꼭 지정해야한다.

### 수정 내용
- 종전에는 `.wrap`에 sprite를 적용했었는데 이 element는 사진 추가 버튼과, 이미지 미리보기 양쪽에 적용되므로 적절치 않다.
- sprites 적용을 `.add-image-caption .sprites-icon-camera` 로 변경하고 `.input-image-container` 를 적절한 위치로 변경함.

https://app.asana.com/0/222280601547638/305519286566506